### PR TITLE
Reading too much from the variable part is not "insufficient data"

### DIFF
--- a/src/mqttproto/_types.py
+++ b/src/mqttproto/_types.py
@@ -1573,11 +1573,11 @@ def decode_packet(
 
     try:
         leftover_data, packet = packet_cls.decode(data[:remaining_length], flags)
-    except InsufficientData:
-        # this is a problem with our code, not a MQTT error
+    except InsufficientData as exc:
+        # this is a problem with our code, not an MQTT error
         raise RuntimeError(
             f"decoding {packet_type._name_} consumed more data than available"
-        )
+        ) from exc
 
     if leftover_data:
         raise MQTTDecodeError(

--- a/src/mqttproto/_types.py
+++ b/src/mqttproto/_types.py
@@ -931,8 +931,8 @@ class MQTTPublishAckPacket(MQTTPacket, PropertiesMixin, ReasonCodeMixin):
     ) -> tuple[memoryview, MQTTPublishAckPacket]:
         # Decode the variable header
         reason_code = ReasonCode.SUCCESS
-        properties = {}
-        user_properties = {}
+        properties: dict[PropertyType, PropertyValue] = {}
+        user_properties: dict[str, str] = {}
 
         data, packet_id = decode_fixed_integer(data, 2)
         if data:
@@ -996,8 +996,8 @@ class MQTTPublishReceivePacket(MQTTPacket, PropertiesMixin, ReasonCodeMixin):
     ) -> tuple[memoryview, MQTTPublishReceivePacket]:
         # Decode the variable header
         reason_code = ReasonCode.SUCCESS
-        properties = {}
-        user_properties = {}
+        properties: dict[PropertyType, PropertyValue] = {}
+        user_properties: dict[str, str] = {}
 
         data, packet_id = decode_fixed_integer(data, 2)
         if data:
@@ -1052,8 +1052,8 @@ class MQTTPublishReleasePacket(MQTTPacket, PropertiesMixin, ReasonCodeMixin):
     ) -> tuple[memoryview, MQTTPublishReleasePacket]:
         # Decode the variable header
         reason_code = ReasonCode.SUCCESS
-        properties = {}
-        user_properties = {}
+        properties: dict[PropertyType, PropertyValue] = {}
+        user_properties: dict[str, str] = {}
 
         data, packet_id = decode_fixed_integer(data, 2)
         if data:
@@ -1107,8 +1107,8 @@ class MQTTPublishCompletePacket(MQTTPacket, PropertiesMixin, ReasonCodeMixin):
     ) -> tuple[memoryview, MQTTPublishCompletePacket]:
         # Decode the variable header
         reason_code = ReasonCode.SUCCESS
-        properties = {}
-        user_properties = {}
+        properties: dict[PropertyType, PropertyValue] = {}
+        user_properties: dict[str, str] = {}
 
         data, packet_id = decode_fixed_integer(data, 2)
         if data:
@@ -1465,8 +1465,8 @@ class MQTTDisconnectPacket(MQTTPacket, PropertiesMixin, ReasonCodeMixin):
     ) -> tuple[memoryview, MQTTDisconnectPacket]:
         # Decode the variable header
         reason_code = ReasonCode.SUCCESS
-        properties = {}
-        user_properties = {}
+        properties: dict[PropertyType, PropertyValue] = {}
+        user_properties: dict[str, str] = {}
 
         if data:
             data, reason_code = cls.decode_reason_code(data)

--- a/src/mqttproto/_types.py
+++ b/src/mqttproto/_types.py
@@ -1464,8 +1464,14 @@ class MQTTDisconnectPacket(MQTTPacket, PropertiesMixin, ReasonCodeMixin):
         cls, data: memoryview, flags: int
     ) -> tuple[memoryview, MQTTDisconnectPacket]:
         # Decode the variable header
-        data, reason_code = cls.decode_reason_code(data)
-        data, properties, user_properties = cls.decode_properties(data)
+        reason_code = ReasonCode.SUCCESS
+        properties = {}
+        user_properties = {}
+
+        if data:
+            data, reason_code = cls.decode_reason_code(data)
+            if data:
+                data, properties, user_properties = cls.decode_properties(data)
 
         return data, MQTTDisconnectPacket(
             reason_code=reason_code,

--- a/src/mqttproto/_types.py
+++ b/src/mqttproto/_types.py
@@ -930,9 +930,15 @@ class MQTTPublishAckPacket(MQTTPacket, PropertiesMixin, ReasonCodeMixin):
         cls, data: memoryview, flags: int
     ) -> tuple[memoryview, MQTTPublishAckPacket]:
         # Decode the variable header
+        reason_code = ReasonCode.SUCCESS
+        properties = {}
+        user_properties = {}
+
         data, packet_id = decode_fixed_integer(data, 2)
-        data, reason_code = cls.decode_reason_code(data)
-        data, properties, user_properties = cls.decode_properties(data)
+        if data:
+            data, reason_code = cls.decode_reason_code(data)
+            if data:
+                data, properties, user_properties = cls.decode_properties(data)
 
         return data, MQTTPublishAckPacket(
             packet_id=packet_id,
@@ -989,9 +995,15 @@ class MQTTPublishReceivePacket(MQTTPacket, PropertiesMixin, ReasonCodeMixin):
         cls, data: memoryview, flags: int
     ) -> tuple[memoryview, MQTTPublishReceivePacket]:
         # Decode the variable header
+        reason_code = ReasonCode.SUCCESS
+        properties = {}
+        user_properties = {}
+
         data, packet_id = decode_fixed_integer(data, 2)
-        data, reason_code = cls.decode_reason_code(data)
-        data, properties, user_properties = cls.decode_properties(data)
+        if data:
+            data, reason_code = cls.decode_reason_code(data)
+            if data:
+                data, properties, user_properties = cls.decode_properties(data)
 
         return data, MQTTPublishReceivePacket(
             packet_id=packet_id,
@@ -1039,9 +1051,15 @@ class MQTTPublishReleasePacket(MQTTPacket, PropertiesMixin, ReasonCodeMixin):
         cls, data: memoryview, flags: int
     ) -> tuple[memoryview, MQTTPublishReleasePacket]:
         # Decode the variable header
+        reason_code = ReasonCode.SUCCESS
+        properties = {}
+        user_properties = {}
+
         data, packet_id = decode_fixed_integer(data, 2)
-        data, reason_code = cls.decode_reason_code(data)
-        data, properties, user_properties = cls.decode_properties(data)
+        if data:
+            data, reason_code = cls.decode_reason_code(data)
+            if data:
+                data, properties, user_properties = cls.decode_properties(data)
 
         return data, MQTTPublishReleasePacket(
             packet_id=packet_id,
@@ -1088,9 +1106,15 @@ class MQTTPublishCompletePacket(MQTTPacket, PropertiesMixin, ReasonCodeMixin):
         cls, data: memoryview, flags: int
     ) -> tuple[memoryview, MQTTPublishCompletePacket]:
         # Decode the variable header
+        reason_code = ReasonCode.SUCCESS
+        properties = {}
+        user_properties = {}
+
         data, packet_id = decode_fixed_integer(data, 2)
-        data, reason_code = cls.decode_reason_code(data)
-        data, properties, user_properties = cls.decode_properties(data)
+        if data:
+            data, reason_code = cls.decode_reason_code(data)
+            if data:
+                data, properties, user_properties = cls.decode_properties(data)
 
         return data, MQTTPublishCompletePacket(
             packet_id=packet_id,

--- a/src/mqttproto/_types.py
+++ b/src/mqttproto/_types.py
@@ -1541,7 +1541,14 @@ def decode_packet(
             f"received {packet_type._name_} with reserved bits set in its fixed header"
         )
 
-    leftover_data, packet = packet_cls.decode(data[:remaining_length], flags)
+    try:
+        leftover_data, packet = packet_cls.decode(data[:remaining_length], flags)
+    except InsufficientData:
+        # this is a problem with our code, not a MQTT error
+        raise RuntimeError(
+            f"decoding {packet_type._name_} consumed more data than available"
+        )
+
     if leftover_data:
         raise MQTTDecodeError(
             f"not all data was consumed when decoding a {packet_type._name_} packet"

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -408,6 +408,17 @@ class TestMQTTPublishAckPacket:
         assert packet2 == packet
         assert not leftover_data
 
+    def test_partial(self) -> None:
+        packet = MQTTPublishAckPacket(packet_id=65534, reason_code=ReasonCode.SUCCESS)
+        buffer = bytearray()
+        buffer2 = bytearray()
+        encode_fixed_integer(packet.packet_id, buffer2, 2)
+
+        packet.encode_fixed_header(0, buffer2, buffer)
+        leftover_data, packet2 = decode_packet(memoryview(buffer))
+        assert packet2 == packet
+        assert not leftover_data
+
     def test_bad_reason_codes(self) -> None:
         for reason_code in ReasonCode.__members__.values():
             if reason_code not in MQTTPublishAckPacket.allowed_reason_codes:
@@ -439,6 +450,19 @@ class TestMQTTPublishReceivePacket:
         buffer = bytearray()
         packet.encode(buffer)
 
+        leftover_data, packet2 = decode_packet(memoryview(buffer))
+        assert packet2 == packet
+        assert not leftover_data
+
+    def test_partial(self) -> None:
+        packet = MQTTPublishReceivePacket(
+            packet_id=65534, reason_code=ReasonCode.SUCCESS
+        )
+        buffer = bytearray()
+        buffer2 = bytearray()
+        encode_fixed_integer(packet.packet_id, buffer2, 2)
+
+        packet.encode_fixed_header(0, buffer2, buffer)
         leftover_data, packet2 = decode_packet(memoryview(buffer))
         assert packet2 == packet
         assert not leftover_data
@@ -478,6 +502,19 @@ class TestMQTTPublishReleasePacket:
         assert packet2 == packet
         assert not leftover_data
 
+    def test_partial(self) -> None:
+        packet = MQTTPublishReleasePacket(
+            packet_id=65534, reason_code=ReasonCode.SUCCESS
+        )
+        buffer = bytearray()
+        buffer2 = bytearray()
+        encode_fixed_integer(packet.packet_id, buffer2, 2)
+
+        packet.encode_fixed_header(2, buffer2, buffer)
+        leftover_data, packet2 = decode_packet(memoryview(buffer))
+        assert packet2 == packet
+        assert not leftover_data
+
     def test_bad_reason_codes(self) -> None:
         for reason_code in ReasonCode.__members__.values():
             if reason_code not in MQTTPublishReleasePacket.allowed_reason_codes:
@@ -509,6 +546,19 @@ class TestMQTTPublishCompletePacket:
         buffer = bytearray()
         packet.encode(buffer)
 
+        leftover_data, packet2 = decode_packet(memoryview(buffer))
+        assert packet2 == packet
+        assert not leftover_data
+
+    def test_partial(self) -> None:
+        packet = MQTTPublishCompletePacket(
+            packet_id=65534, reason_code=ReasonCode.SUCCESS
+        )
+        buffer = bytearray()
+        buffer2 = bytearray()
+        encode_fixed_integer(packet.packet_id, buffer2, 2)
+
+        packet.encode_fixed_header(0, buffer2, buffer)
         leftover_data, packet2 = decode_packet(memoryview(buffer))
         assert packet2 == packet
         assert not leftover_data
@@ -718,6 +768,15 @@ class TestMQTTDisconnectPacket:
         buffer = bytearray()
         packet.encode(buffer)
 
+        leftover_data, packet2 = decode_packet(memoryview(buffer))
+        assert packet2 == packet
+        assert not leftover_data
+
+    def test_partial(self) -> None:
+        packet = MQTTDisconnectPacket(reason_code=ReasonCode.NORMAL_DISCONNECTION)
+        buffer = bytearray()
+
+        packet.encode_fixed_header(0, b"", buffer)
         leftover_data, packet2 = decode_packet(memoryview(buffer))
         assert packet2 == packet
         assert not leftover_data


### PR DESCRIPTION
This causes a lock-up when we talk with a broker that shortens its PUBACK messages.