### PR TITLE
Don't publish with unsupported QoS

### DIFF
--- a/src/mqttproto/async_client.py
+++ b/src/mqttproto/async_client.py
@@ -480,13 +480,12 @@ class AsyncMQTTClient:
         if operation.exception:
             raise operation.exception
 
-    def supports_qos(self, qos: QoS) -> bool:
+    @property
+    def maximum_qos(self) -> QoS:
         """
-        Check if the broker supports this QoS level.
-
-        :param qos: The desired QoS value.
+        Returns the maximum QoS level that the broker supports.
         """
-        return self._state_machine.supports_qos(qos)
+        return self._state_machine.maximum_qos
 
     async def publish(
         self,

--- a/src/mqttproto/async_client.py
+++ b/src/mqttproto/async_client.py
@@ -480,6 +480,14 @@ class AsyncMQTTClient:
         if operation.exception:
             raise operation.exception
 
+    def supports_qos(self, qos: QoS) -> bool:
+        """
+        Check if the broker supports this QoS level.
+
+        :param qos: The desired QoS value.
+        """
+        return self._state_machine.supports_qos(qos)
+
     async def publish(
         self,
         topic: str,

--- a/src/mqttproto/client_state_machine.py
+++ b/src/mqttproto/client_state_machine.py
@@ -157,7 +157,6 @@ class MQTTClientStateMachine(BaseMQTTClientStateMachine):
 
         """
         self._out_require_state(MQTTClientState.CONNECTED)
-        qos = min(qos, self._maximum_qos)
         packet_id = self._generate_packet_id() if qos > QoS.AT_MOST_ONCE else None
         packet = MQTTPublishPacket(
             topic=topic, payload=payload, qos=qos, retain=retain, packet_id=packet_id

--- a/src/mqttproto/client_state_machine.py
+++ b/src/mqttproto/client_state_machine.py
@@ -37,7 +37,7 @@ class MQTTClientStateMachine(BaseMQTTClientStateMachine):
         validator=instance_of(str), factory=lambda: f"mqttproto-{uuid4().hex}"
     )
     _ping_pending: bool = field(init=False, default=False)
-    _maximum_qos: bool = field(init=False, default=QoS.EXACTLY_ONCE)
+    _maximum_qos: QoS = field(init=False, default=QoS.EXACTLY_ONCE)
     _subscriptions: dict[str, Subscription] = field(init=False, factory=dict)
     _subscription_counts: dict[str, int] = field(
         init=False, factory=lambda: defaultdict(lambda: 0)

--- a/src/mqttproto/client_state_machine.py
+++ b/src/mqttproto/client_state_machine.py
@@ -168,13 +168,12 @@ class MQTTClientStateMachine(BaseMQTTClientStateMachine):
 
         return packet.packet_id
 
-    def supports_qos(self, qos: QoS) -> bool:
+    @property
+    def maximum_qos(self) -> QoS:
         """
-        Check if the broker supports this QoS level.
-
-        :param qos: The desired QoS value.
+        Returns the maximum QoS level that the broker supports.
         """
-        return qos <= self._maximum_qos
+        return self._maximum_qos
 
     def subscribe(self, subscriptions: Sequence[Subscription]) -> int | None:
         """

--- a/src/mqttproto/client_state_machine.py
+++ b/src/mqttproto/client_state_machine.py
@@ -71,7 +71,8 @@ class MQTTClientStateMachine(BaseMQTTClientStateMachine):
                     str, packet.properties.get(PropertyType.AUTHENTICATION_METHOD)
                 )
                 self._maximum_qos = cast(
-                    QoS, packet.properties.get(PropertyType.MAXIMUM_QOS, QoS.EXACTLY_ONCE)
+                    QoS,
+                    packet.properties.get(PropertyType.MAXIMUM_QOS, QoS.EXACTLY_ONCE),
                 )
 
                 self.reset(session_present=packet.session_present)

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -27,8 +27,10 @@ async def test_publish_subscribe(qos_sub: QoS, qos_pub: QoS) -> None:
 
             assert packets[0].topic == "test/text"
             assert packets[0].payload == "test åäö"
+            assert packets[0].qos == min(qos_sub, qos_pub)
             assert packets[1].topic == "test/binary"
             assert packets[1].payload == b"\x00\xff\x00\x1f"
+            assert packets[1].qos == min(qos_sub, qos_pub)
 
 
 async def test_retained_message() -> None:

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -18,6 +18,7 @@ async def test_publish_subscribe(qos_sub: QoS, qos_pub: QoS) -> None:
     async with AsyncMQTTClient() as client:
         if qos_pub > client.maximum_qos:
             return  # TODO add pytest.skip
+
         async with client.subscribe("test/+", maximum_qos=qos_sub) as messages:
             await client.publish("test/text", "test åäö", qos=qos_pub)
             await client.publish("test/binary", b"\x00\xff\x00\x1f", qos=qos_pub)

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -16,6 +16,8 @@ pytestmark = [pytest.mark.anyio, pytest.mark.network]
 )
 async def test_publish_subscribe(qos_sub: QoS, qos_pub: QoS) -> None:
     async with AsyncMQTTClient() as client:
+        if qos_pub > client.maximum_qos:
+            return  # TODO add pytest.skip
         async with client.subscribe("test/+", maximum_qos=qos_sub) as messages:
             await client.publish("test/text", "test åäö", qos=qos_pub)
             await client.publish("test/binary", b"\x00\xff\x00\x1f", qos=qos_pub)

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -8,12 +8,13 @@ from mqttproto.async_client import AsyncMQTTClient
 pytestmark = [pytest.mark.anyio, pytest.mark.network]
 
 
-@pytest.mark.parametrize("qos", [QoS.AT_MOST_ONCE, QoS.AT_LEAST_ONCE, QoS.EXACTLY_ONCE])
-async def test_publish_subscribe(qos: QoS) -> None:
+@pytest.mark.parametrize("qos_sub", [QoS.AT_MOST_ONCE, QoS.AT_LEAST_ONCE, QoS.EXACTLY_ONCE])
+@pytest.mark.parametrize("qos_pub", [QoS.AT_MOST_ONCE, QoS.AT_LEAST_ONCE, QoS.EXACTLY_ONCE])
+async def test_publish_subscribe(qos_sub: QoS, qos_pub:QoS) -> None:
     async with AsyncMQTTClient() as client:
-        async with client.subscribe("test/+") as messages:
-            await client.publish("test/text", "test åäö", qos=qos)
-            await client.publish("test/binary", b"\x00\xff\x00\x1f", qos=qos)
+        async with client.subscribe("test/+", maximum_qos=qos_sub) as messages:
+            await client.publish("test/text", "test åäö", qos=qos_pub)
+            await client.publish("test/binary", b"\x00\xff\x00\x1f", qos=qos_pub)
             packets: list[MQTTPublishPacket] = []
             async for packet in messages:
                 packets.append(packet)

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -8,9 +8,13 @@ from mqttproto.async_client import AsyncMQTTClient
 pytestmark = [pytest.mark.anyio, pytest.mark.network]
 
 
-@pytest.mark.parametrize("qos_sub", [QoS.AT_MOST_ONCE, QoS.AT_LEAST_ONCE, QoS.EXACTLY_ONCE])
-@pytest.mark.parametrize("qos_pub", [QoS.AT_MOST_ONCE, QoS.AT_LEAST_ONCE, QoS.EXACTLY_ONCE])
-async def test_publish_subscribe(qos_sub: QoS, qos_pub:QoS) -> None:
+@pytest.mark.parametrize(
+    "qos_sub", [QoS.AT_MOST_ONCE, QoS.AT_LEAST_ONCE, QoS.EXACTLY_ONCE]
+)
+@pytest.mark.parametrize(
+    "qos_pub", [QoS.AT_MOST_ONCE, QoS.AT_LEAST_ONCE, QoS.EXACTLY_ONCE]
+)
+async def test_publish_subscribe(qos_sub: QoS, qos_pub: QoS) -> None:
     async with AsyncMQTTClient() as client:
         async with client.subscribe("test/+", maximum_qos=qos_sub) as messages:
             await client.publish("test/text", "test åäö", qos=qos_pub)

--- a/tests/test_state_machines.py
+++ b/tests/test_state_machines.py
@@ -105,7 +105,7 @@ def test_client_publish_qos0(
 
 
 @pytest.mark.parametrize("qos", [QoS.AT_MOST_ONCE, QoS.AT_LEAST_ONCE, QoS.EXACTLY_ONCE])
-def test_client_limit_qos(qos) -> None:
+def test_client_limit_qos(qos: QoS) -> None:
     """Test that a limited QoS is processed in the client."""
     client = MQTTClientStateMachine(client_id="client-X")
     client.connect()

--- a/tests/test_state_machines.py
+++ b/tests/test_state_machines.py
@@ -110,7 +110,6 @@ def test_client_limit_qos(qos) -> None:
     client = MQTTClientStateMachine(client_id="client-X")
     client.connect()
     assert client.state is MQTTClientState.CONNECTING
-    _bytes = client.get_outbound_data()  # ignored
 
     packet = MQTTConnAckPacket(
         reason_code=ReasonCode.SUCCESS,

--- a/tests/test_state_machines.py
+++ b/tests/test_state_machines.py
@@ -106,7 +106,7 @@ def test_client_publish_qos0(
 
 @pytest.mark.parametrize("qos", [QoS.AT_MOST_ONCE, QoS.AT_LEAST_ONCE, QoS.EXACTLY_ONCE])
 def test_client_limit_qos(qos) -> None:
-    """Test that a limited QoS is processed in the client"""
+    """Test that a limited QoS is processed in the client."""
     client = MQTTClientStateMachine(client_id="client-X")
     client.connect()
     assert client.state is MQTTClientState.CONNECTING


### PR DESCRIPTION
MQTT 3.3.1.2:
If the Server included a Maximum QoS in its CONNACK response to a Client and it receives a PUBLISH packet with a QoS greater than this, then it uses DISCONNECT with Reason Code 0x9B (QoS not supported) …