### PR TITLE
Add a "may_retain" attribute

### DIFF
--- a/src/mqttproto/async_client.py
+++ b/src/mqttproto/async_client.py
@@ -286,6 +286,10 @@ class AsyncMQTTClient:
 
         self._state_machine = MQTTClientStateMachine(client_id=self.client_id)
 
+    @property
+    def may_retain(self):
+        return self._state_machine.may_retain
+
     async def __aenter__(self) -> Self:
         async with AsyncExitStack() as exit_stack:
             task_group = await exit_stack.enter_async_context(create_task_group())

--- a/src/mqttproto/async_client.py
+++ b/src/mqttproto/async_client.py
@@ -287,7 +287,7 @@ class AsyncMQTTClient:
         self._state_machine = MQTTClientStateMachine(client_id=self.client_id)
 
     @property
-    def may_retain(self):
+    def may_retain(self) -> bool:
         return self._state_machine.may_retain
 
     async def __aenter__(self) -> Self:

--- a/src/mqttproto/client_state_machine.py
+++ b/src/mqttproto/client_state_machine.py
@@ -37,6 +37,7 @@ class MQTTClientStateMachine(BaseMQTTClientStateMachine):
         validator=instance_of(str), factory=lambda: f"mqttproto-{uuid4().hex}"
     )
     _ping_pending: bool = field(init=False, default=False)
+    may_retain: bool = field(init=False, default=True)
     _subscriptions: dict[str, Subscription] = field(init=False, factory=dict)
     _subscription_counts: dict[str, int] = field(
         init=False, factory=lambda: defaultdict(lambda: 0)
@@ -69,7 +70,9 @@ class MQTTClientStateMachine(BaseMQTTClientStateMachine):
                 self._auth_method = cast(
                     str, packet.properties.get(PropertyType.AUTHENTICATION_METHOD)
                 )
-
+                self.may_retain = cast(
+                    bool, packet.properties.get(PropertyType.RETAIN_AVAILABLE)
+                )
                 self.reset(session_present=packet.session_present)
 
                 # Resend any pending publishes (and set the duplicate flag)
@@ -149,6 +152,9 @@ class MQTTClientStateMachine(BaseMQTTClientStateMachine):
             topic too
         :return: the packet ID if ``qos`` was higher than 0
 
+        A QoS that's not supported by the server is silently downgraded.
+        If Retain is not supported, the message is sent as-is because
+        the server is free to accept it anyway.
         """
         self._out_require_state(MQTTClientState.CONNECTED)
         packet_id = self._generate_packet_id() if qos > QoS.AT_MOST_ONCE else None

--- a/src/mqttproto/client_state_machine.py
+++ b/src/mqttproto/client_state_machine.py
@@ -71,7 +71,7 @@ class MQTTClientStateMachine(BaseMQTTClientStateMachine):
                     str, packet.properties.get(PropertyType.AUTHENTICATION_METHOD)
                 )
                 self.may_retain = cast(
-                    bool, packet.properties.get(PropertyType.RETAIN_AVAILABLE)
+                    bool, packet.properties.get(PropertyType.RETAIN_AVAILABLE, True)
                 )
                 self.reset(session_present=packet.session_present)
 

--- a/src/mqttproto/sync_client.py
+++ b/src/mqttproto/sync_client.py
@@ -75,6 +75,10 @@ class MQTTClient:
             **kwargs,
         )
 
+    @property
+    def may_retain(self) -> bool:
+        return self._async_client.may_retain
+
     def __enter__(self) -> Self:
         with ExitStack() as exit_stack:
             self._portal = exit_stack.enter_context(portal_provider)

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -7,6 +7,9 @@ import pytest
 from mqttproto import MQTTPublishPacket, QoS
 from mqttproto.async_client import AsyncMQTTClient
 
+if sys.version_info < (3, 11):
+    from exceptiongroup import BaseExceptionGroup
+
 pytestmark = [pytest.mark.anyio, pytest.mark.network]
 
 
@@ -26,12 +29,6 @@ async def test_publish_subscribe(qos: QoS) -> None:
             assert packets[0].payload == "test åäö"
             assert packets[1].topic == "test/binary"
             assert packets[1].payload == b"\x00\xff\x00\x1f"
-
-
-if sys.version_info < (3, 11):
-
-    class BaseExceptionGroup(BaseException):
-        exceptions: list[BaseExceptionGroup] = []
 
 
 async def test_retained_message() -> None:

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import sys
+
 import pytest
 
 from mqttproto import MQTTPublishPacket, QoS
@@ -24,6 +26,12 @@ async def test_publish_subscribe(qos: QoS) -> None:
             assert packets[0].payload == "test åäö"
             assert packets[1].topic == "test/binary"
             assert packets[1].payload == b"\x00\xff\x00\x1f"
+
+
+if sys.version_info < (3, 11):
+
+    class BaseExceptionGroup(BaseException):
+        exceptions: list[BaseExceptionGroup] = []
 
 
 async def test_retained_message() -> None:

--- a/tests/test_state_machines.py
+++ b/tests/test_state_machines.py
@@ -11,6 +11,7 @@ from mqttproto import (
     MQTTPublishPacket,
     MQTTPublishReceivePacket,
     MQTTPublishReleasePacket,
+    PropertyType,
     QoS,
     ReasonCode,
     Subscription,
@@ -290,3 +291,24 @@ def test_client_receive_qos2(
     packet = packets[0]
     assert isinstance(packet, MQTTPublishCompletePacket)
     assert packet.reason_code is ReasonCode.SUCCESS
+
+
+@pytest.mark.parametrize("retain", [None, False, True])
+def test_client_retain(retain: bool | None) -> None:
+    """Test that server's RETAINability is processed in the client"""
+    client = MQTTClientStateMachine(client_id="client-X")
+    client.connect()
+    assert client.state is MQTTClientState.CONNECTING
+    _bytes = client.get_outbound_data()  # ignored
+
+    packet = MQTTConnAckPacket(
+        reason_code=ReasonCode.SUCCESS,
+        session_present=False,
+        properties={PropertyType.RETAIN_AVAILABLE: retain}
+        if retain is not None
+        else {},
+    )
+    buffer = bytearray()
+    packet.encode(buffer)
+    client.feed_bytes(buffer)
+    assert client.may_retain == (retain is not False)

--- a/tests/test_sync_client.py
+++ b/tests/test_sync_client.py
@@ -27,10 +27,17 @@ def test_publish_subscribe(qos: QoS) -> None:
 
 
 def test_retained_message() -> None:
-    with MQTTClient() as client:
-        client.publish("retainedtest", "test åäö", retain=True)
-        with client.subscribe("retainedtest") as messages:
-            for packet in messages:
-                assert packet.topic == "retainedtest"
-                assert packet.payload == "test åäö"
-                break
+    try:
+        with MQTTClient() as client:
+            if not client.may_retain:
+                pytest.skip("Retain not available")
+            client.publish("retainedtest", "test åäö", retain=True)
+            with client.subscribe("retainedtest") as messages:
+                for packet in messages:
+                    assert packet.topic == "retainedtest"
+                    assert packet.payload == "test åäö"
+                    break
+    except BaseExceptionGroup as exc:
+        while isinstance(exc, BaseExceptionGroup) and len(exc.exceptions) == 1:
+            exc = exc.exceptions[0]
+        raise exc

--- a/tests/test_sync_client.py
+++ b/tests/test_sync_client.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import sys
+
 import pytest
 
 from mqttproto import MQTTPublishPacket, QoS
@@ -24,6 +26,12 @@ def test_publish_subscribe(qos: QoS) -> None:
             assert packets[0].payload == "test åäö"
             assert packets[1].topic == "test/binary"
             assert packets[1].payload == b"\x00\xff\x00\x1f"
+
+
+if sys.version_info < (3, 11):
+
+    class BaseExceptionGroup(BaseException):
+        exceptions: list[BaseExceptionGroup] = []
 
 
 def test_retained_message() -> None:


### PR DESCRIPTION
The client might need to know whether the server supports Retain.
(We certainly do, when testing.)

In contrast to silently downgrading QoS when publishing, I decided to send the message anyway because there are servers who can be configured to say that they don't accept Retained messages, but do it anyway (and relay the flag to bridges and whatnot).