### PR TITLE
Subscription identifiers (client only)

### DIFF
--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -103,6 +103,10 @@ fine too:
     hurts code readability, try using :class:`~contextlib.AsyncExitStack` to manage the
     context managers.
 
+While the MQTT protocol doesn't support multiple subscriptions to the same
+topic pattern, :meth:`~.AsyncMQTTClient.subscribe` hides that from you —
+albeit with some restrictions.
+
 .. seealso:: :meth:`~.AsyncMQTTClient.subscribe`
 
 Publishing messages

--- a/src/mqttproto/_types.py
+++ b/src/mqttproto/_types.py
@@ -472,6 +472,7 @@ class Subscription:
             if "+" in part:
                 if prefix:
                     prefix += "/"
+
                 if len(part) != 1:
                     # MQTT-4.7.1-2
                     raise InvalidPattern(
@@ -486,12 +487,14 @@ class Subscription:
                         "multi-level wildcard ('#') must occupy an entire level of the "
                         "topic filter"
                     )
+
                 if i != len(parts) - 1:
                     # MQTT-4.7.1-1
                     raise InvalidPattern(
                         "multi-level wildcard ('#') must be the last character in the "
                         "topic filter"
                     )
+
                 if prefix is not None:
                     self._only_hash = True
             else:
@@ -499,7 +502,9 @@ class Subscription:
                     n_chop += 1
                     if prefix:
                         prefix += "/"
+
                     prefix += part
+
                 continue
 
             if prefix is not None:
@@ -512,6 +517,7 @@ class Subscription:
         # Save the group ID for a shared subscription
         if len(parts) > 2 and parts[0] == "$share":
             self.group_id = parts[1]
+
         self._parts = parts[n_chop:]
 
     def __eq__(self, other: object) -> bool:
@@ -1233,6 +1239,7 @@ class MQTTSubscribePacket(MQTTPacket, PropertiesMixin):
             )
             if subscr_id:
                 subscription.subscription_id = subscr_id[0]
+
             subscriptions.append(subscription)
 
         return data, MQTTSubscribePacket(

--- a/src/mqttproto/_types.py
+++ b/src/mqttproto/_types.py
@@ -458,6 +458,7 @@ class Subscription:
     retain_handling: RetainHandling = field(
         kw_only=True, default=RetainHandling.SEND_RETAINED
     )
+    subscription_id: int = field(kw_only=True, default=0)
     group_id: str | None = field(init=False, default=None)
     _parts: tuple[str, ...] = field(init=False, repr=False, eq=False)
     _prefix: str | None = field(init=False, repr=False, eq=False)
@@ -1224,6 +1225,11 @@ class MQTTSubscribePacket(MQTTPacket, PropertiesMixin):
         subscriptions: list[Subscription] = []
         while data:
             data, subscription = Subscription.decode(data)
+            subscr_id = cast(
+                "list[int] | None", properties.get(PropertyType.SUBSCRIPTION_IDENTIFIER)
+            )
+            if subscr_id:
+                subscription.subscription_id = subscr_id[0]
             subscriptions.append(subscription)
 
         return data, MQTTSubscribePacket(

--- a/src/mqttproto/async_client.py
+++ b/src/mqttproto/async_client.py
@@ -556,6 +556,7 @@ class AsyncMQTTClient:
     def _new_subscr_id(self) -> int:
         if not self.may_subscription_id:
             return 0
+
         sid = self._last_subscr_id
         while True:
             sid += 1
@@ -567,8 +568,10 @@ class AsyncMQTTClient:
                 and len(self._subscription_ids) < self._last_subscr_id / 5
             ):
                 sid = 1
+
             if sid in self._subscription_ids:
                 continue
+
             self._last_subscr_id = sid
             return sid
 
@@ -657,10 +660,12 @@ class AsyncMQTTClient:
                             raise ValueError(
                                 f"Conflicting 'retain_as_published' option for {pattern}"
                             )
+
                         if retain_handling == RetainHandling.SEND_RETAINED:
                             raise ValueError(
                                 f"Already subscribed: cannot get retained messages for {pattern}"
                             )
+
                         if subscr.max_qos >= maximum_qos:
                             # nothing to do
                             continue

--- a/src/mqttproto/async_client.py
+++ b/src/mqttproto/async_client.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import logging
 import sys
-from collections.abc import AsyncGenerator, Container, Sequence
+from collections.abc import AsyncGenerator, Container
 from contextlib import AsyncExitStack, ExitStack, asynccontextmanager
 from ssl import SSLContext, SSLError
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar, cast
 
 import stamina
 from anyio import (
@@ -14,6 +14,7 @@ from anyio import (
     ClosedResourceError,
     Event,
     Lock,
+    WouldBlock,
     aclose_forcefully,
     connect_tcp,
     connect_unix,
@@ -97,14 +98,20 @@ class MQTTWebsocketStream(ByteStream):
 
 
 @define(eq=False)
+class ClientSubscription(Subscription):
+    users: set[AsyncMQTTSubscription] = field(init=False, factory=set)
+
+
+@define(eq=False)
 class AsyncMQTTSubscription:
-    subscriptions: Sequence[Subscription]
+    subscriptions: list[ClientSubscription] = field(init=False, factory=list)
     send_stream: MemoryObjectSendStream[MQTTPublishPacket] = field(
         init=False, repr=False
     )
     _receive_stream: MemoryObjectReceiveStream[MQTTPublishPacket] = field(
         init=False, repr=False
     )
+    subscription_id: int | None = field(init=False, repr=True, default=None)
 
     def __attrs_post_init__(self) -> None:
         self.send_stream, self._receive_stream = create_memory_object_stream[
@@ -131,7 +138,10 @@ class AsyncMQTTSubscription:
         return None
 
     def matches(self, publish: MQTTPublishPacket) -> bool:
-        return any(sub.matches(publish) for sub in self.subscriptions)
+        return any(
+            not sub.subscription_id and sub.matches(publish)
+            for sub in self.subscriptions
+        )
 
 
 @define(eq=False)
@@ -262,7 +272,11 @@ class AsyncMQTTClient:
     _exit_stack: AsyncExitStack = field(init=False)
     _closed: bool = field(init=False, default=False)
     _state_machine: MQTTClientStateMachine = field(init=False)
-    _subscriptions: list[AsyncMQTTSubscription] = field(init=False, factory=list)
+    _subscribe_lock: Lock = field(init=False, factory=Lock)
+    _subscriptions: dict[str, ClientSubscription] = field(init=False, factory=dict)
+    _subscription_ids: dict[int, ClientSubscription] = field(init=False, factory=dict)
+    _subscription_no_id: dict[str, ClientSubscription] = field(init=False, factory=dict)
+    _last_subscr_id: int = field(init=False, default=0)
     _stream: ByteStream = field(init=False)
     _stream_lock: Lock = field(init=False, factory=Lock)
     _pending_connect: MQTTConnectOperation | None = field(init=False, default=None)
@@ -407,9 +421,24 @@ class AsyncMQTTClient:
 
     async def _deliver_publish(self, packet: MQTTPublishPacket) -> None:
         async with create_task_group() as tg:
-            for sub in self._subscriptions:
-                if sub.matches(packet):
-                    tg.start_soon(sub.send_stream.send, packet)
+
+            def send(subscr: ClientSubscription) -> None:
+                for client in subscr.users:
+                    try:
+                        client.send_stream.send_nowait(packet)
+                    except WouldBlock:
+                        tg.start_soon(client.send_stream.send, packet)
+
+            if subscr_ids := packet.properties.get(
+                PropertyType.SUBSCRIPTION_IDENTIFIER
+            ):
+                for subscr_id in cast("list[int]", subscr_ids):
+                    if sub := self._subscription_ids.get(subscr_id):
+                        send(sub)
+            else:
+                for sub in self._subscription_no_id.values():
+                    if sub.matches(packet):
+                        send(sub)
 
     @asynccontextmanager
     async def _connect_mqtt(
@@ -524,6 +553,25 @@ class AsyncMQTTClient:
         else:
             await self._run_operation(MQTTQoS0PublishOperation())
 
+    def _new_subscr_id(self) -> int:
+        if not self.may_subscription_id:
+            return 0
+        sid = self._last_subscr_id
+        while True:
+            sid += 1
+            # If there are sufficiently large and/or many holes in the list
+            # of assigned subscription IDs, restart from the beginning:
+            # larger IDs take up more space in the message.
+            if (
+                sid in (128, 16384)
+                and len(self._subscription_ids) < self._last_subscr_id / 5
+            ):
+                sid = 1
+            if sid in self._subscription_ids:
+                continue
+            self._last_subscr_id = sid
+            return sid
+
     @asynccontextmanager
     async def subscribe(
         self,
@@ -554,45 +602,106 @@ class AsyncMQTTClient:
         :return: an async context manager that will yield messages matching the
             subscribed topics/patterns
 
+        Subscribing to the same topic pattern multiple times is supported,
+        with these restrictions:
+
+            * the `retain_as_published` and `no_local` flags must match.
+
+            * subsequent subscriptions can't use `RetainHandling.SEND_RETAINED`.
+
+            * When a second subscription raises the subscription's maximum QoS,
+              it's not lowered when the second subscription ends.
         """
         if not patterns:
             raise ValueError("no subscription patterns given")
 
         async def unsubscribe() -> None:
-            # Send an unsubscribe request if any of these patterns are not used by
-            # another subscription in this client
-            if unsubscribe_packet_id := self._state_machine.unsubscribe(patterns):
-                unsubscribe_op = MQTTUnsubscribeOperation(unsubscribe_packet_id)
-                try:
-                    await self._run_operation(unsubscribe_op)
-                except MQTTUnsubscribeFailed as exc:
-                    logger.warning("Unsubscribe failed: %s", exc)
+            # Send an unsubscribe request if any of my subscriptions are unused
+            async with self._subscribe_lock:
+                patterns: list[str] = []
+                for subscr in subscription.subscriptions:
+                    subscr.users.discard(subscription)
+                    if not subscr.users:
+                        patterns.append(subscr.pattern)
+                        del self._subscriptions[subscr.pattern]
+                        if subscr.subscription_id:
+                            del self._subscription_ids[subscr.subscription_id]
+                        else:
+                            del self._subscription_no_id[pattern]
+
+                if patterns:
+                    if unsubscribe_packet_id := self._state_machine.unsubscribe(
+                        patterns
+                    ):
+                        unsubscribe_op = MQTTUnsubscribeOperation(unsubscribe_packet_id)
+                        try:
+                            await self._run_operation(unsubscribe_op)
+                        except MQTTUnsubscribeFailed as exc:
+                            logger.warning("Unsubscribe failed: %s", exc)
 
         async with AsyncExitStack() as exit_stack:
-            subscriptions = [
-                Subscription(
-                    pattern=pattern,
-                    max_qos=maximum_qos,
-                    no_local=no_local,
-                    retain_as_published=retain_as_published,
-                    retain_handling=retain_handling,
-                )
-                for pattern in patterns
-            ]
-
-            # Set up a local subscription that will receive matching publishes as soon
-            # as the broker starts sending them
-            subscription = AsyncMQTTSubscription(subscriptions)
+            subscription = AsyncMQTTSubscription()
             exit_stack.enter_context(subscription)
-            self._subscriptions.append(subscription)
-            exit_stack.callback(self._subscriptions.remove, subscription)
-
-            # Send a subscribe request if any of these patterns hasn't been subscribed
-            # to by this client already
-            if subscribe_packet_id := self._state_machine.subscribe(subscriptions):
-                subscribe_op = MQTTSubscribeOperation(subscribe_packet_id)
-                await self._run_operation(subscribe_op)
-
-            # Set up an unsubscribe operation when the async context manager is exited
             exit_stack.push_async_callback(unsubscribe)
+
+            to_subscribe: list[ClientSubscription] = []
+
+            async with self._subscribe_lock:
+                for pattern in patterns:
+                    if subscr := self._subscriptions.get(pattern):
+                        if subscr.no_local != no_local:
+                            raise ValueError(
+                                f"Conflicting 'no_local' option for {pattern}"
+                            )
+                        if subscr.retain_as_published != retain_as_published:
+                            raise ValueError(
+                                f"Conflicting 'retain_as_published' option for {pattern}"
+                            )
+                        if retain_handling == RetainHandling.SEND_RETAINED:
+                            raise ValueError(
+                                f"Already subscribed: cannot get retained messages for {pattern}"
+                            )
+                        if subscr.max_qos >= maximum_qos:
+                            # nothing to do
+                            continue
+                    else:
+                        subscr = ClientSubscription(
+                            pattern=pattern,
+                            max_qos=maximum_qos,
+                            no_local=no_local,
+                            retain_as_published=retain_as_published,
+                            retain_handling=retain_handling,
+                            subscription_id=self._new_subscr_id(),
+                        )
+                        self._subscriptions[pattern] = subscr
+                        if subscr.subscription_id:
+                            self._subscription_ids[subscr.subscription_id] = subscr
+                        else:
+                            self._subscription_no_id[pattern] = subscr
+
+                    # link the subscription
+                    subscription.subscriptions.append(subscr)
+                    subscr.users.add(subscription)
+
+                    if subscr.subscription_id:
+                        # every topic has (in fact, needs) its own ID.
+                        subscribe_packet_id = self._state_machine.subscribe(
+                            [subscr], max_qos=maximum_qos
+                        )
+                        subscribe_op = MQTTSubscribeOperation(subscribe_packet_id)
+                        await self._run_operation(subscribe_op)
+                        subscr.max_qos = max(maximum_qos, subscr.max_qos)
+                    else:
+                        to_subscribe.append(subscr)
+
+                if to_subscribe:
+                    # no subscription IDs, so do it all at once
+                    subscribe_packet_id = self._state_machine.subscribe(
+                        to_subscribe, max_qos=maximum_qos
+                    )
+                    subscribe_op = MQTTSubscribeOperation(subscribe_packet_id)
+                    await self._run_operation(subscribe_op)
+                    for subscr in to_subscribe:
+                        subscr.max_qos = max(maximum_qos, subscr.max_qos)
+
             yield subscription

--- a/src/mqttproto/async_client.py
+++ b/src/mqttproto/async_client.py
@@ -290,6 +290,10 @@ class AsyncMQTTClient:
     def may_retain(self) -> bool:
         return self._state_machine.may_retain
 
+    @property
+    def may_subscription_id(self) -> bool:
+        return self._state_machine.may_subscription_id
+
     async def __aenter__(self) -> Self:
         async with AsyncExitStack() as exit_stack:
             task_group = await exit_stack.enter_async_context(create_task_group())

--- a/src/mqttproto/broker_state_machine.py
+++ b/src/mqttproto/broker_state_machine.py
@@ -19,6 +19,7 @@ from ._types import (
     MQTTSubscribePacket,
     MQTTUnsubscribeAckPacket,
     MQTTUnsubscribePacket,
+    PropertyType,
     ReasonCode,
     Subscription,
 )
@@ -200,9 +201,11 @@ class MQTTBrokerClientStateMachine(BaseMQTTClientStateMachine):
         else:
             self._state = MQTTClientState.DISCONNECTED
 
-        MQTTConnAckPacket(
+        ack = MQTTConnAckPacket(
             reason_code=reason_code, session_present=session_present
-        ).encode(self._out_buffer)
+        )
+        ack.properties[PropertyType.SUBSCRIPTION_IDENTIFIER_AVAILABLE] = False
+        ack.encode(self._out_buffer)
 
     def acknowledge_subscribe(
         self, packet_id: int, reason_codes: Sequence[ReasonCode]

--- a/src/mqttproto/client_state_machine.py
+++ b/src/mqttproto/client_state_machine.py
@@ -38,6 +38,7 @@ class MQTTClientStateMachine(BaseMQTTClientStateMachine):
     )
     _ping_pending: bool = field(init=False, default=False)
     _may_retain: bool = field(init=False, default=True)
+    _may_subscription_id: bool = field(init=False, default=True)
     _maximum_qos: QoS = field(init=False, default=QoS.EXACTLY_ONCE)
     _subscriptions: dict[str, Subscription] = field(init=False, factory=dict)
     _subscription_counts: dict[str, int] = field(
@@ -52,6 +53,11 @@ class MQTTClientStateMachine(BaseMQTTClientStateMachine):
     def may_retain(self) -> bool:
         """Does the server support RETAINed messages?"""
         return self._may_retain
+
+    @property
+    def may_subscription_id(self) -> bool:
+        """Does the server support RETAINed messages?"""
+        return self._may_subscription_id
 
     def reset(self, session_present: bool) -> None:
         self._ping_pending = False
@@ -78,6 +84,12 @@ class MQTTClientStateMachine(BaseMQTTClientStateMachine):
                 )
                 self._may_retain = cast(
                     bool, packet.properties.get(PropertyType.RETAIN_AVAILABLE, True)
+                )
+                self._may_subscription_id = cast(
+                    bool,
+                    packet.properties.get(
+                        PropertyType.SUBSCRIPTION_IDENTIFIER_AVAILABLE, True
+                    ),
                 )
                 self._maximum_qos = cast(
                     QoS,

--- a/src/mqttproto/client_state_machine.py
+++ b/src/mqttproto/client_state_machine.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections import defaultdict
 from collections.abc import Sequence
 from typing import cast
 from uuid import uuid4
@@ -9,6 +8,7 @@ from attr.validators import instance_of
 from attrs import define, field
 
 from ._base_client_state_machine import BaseMQTTClientStateMachine, MQTTClientState
+from ._exceptions import MQTTProtocolError
 from ._types import (
     MQTTConnAckPacket,
     MQTTConnectPacket,
@@ -40,10 +40,6 @@ class MQTTClientStateMachine(BaseMQTTClientStateMachine):
     _may_retain: bool = field(init=False, default=True)
     _may_subscription_id: bool = field(init=False, default=True)
     _maximum_qos: QoS = field(init=False, default=QoS.EXACTLY_ONCE)
-    _subscriptions: dict[str, Subscription] = field(init=False, factory=dict)
-    _subscription_counts: dict[str, int] = field(
-        init=False, factory=lambda: defaultdict(lambda: 0)
-    )
 
     def __init__(self, client_id: str | None = None):
         self.__attrs_init__(client_id=client_id or f"mqttproto-{uuid4().hex}")
@@ -69,7 +65,6 @@ class MQTTClientStateMachine(BaseMQTTClientStateMachine):
             }
         else:
             self._next_packet_id = 1
-            self._subscriptions.clear()
 
     def _handle_packet(self, packet: MQTTPacket) -> bool:
         if super()._handle_packet(packet):
@@ -198,34 +193,44 @@ class MQTTClientStateMachine(BaseMQTTClientStateMachine):
         """
         return self._maximum_qos
 
-    def subscribe(self, subscriptions: Sequence[Subscription]) -> int | None:
+    def subscribe(
+        self, subscriptions: Sequence[Subscription], max_qos: QoS | None = None
+    ) -> int:
         """
         Subscribe to one or more topic patterns.
 
-        If any of the given subscription was
         Send a ``SUBSCRIBE`` request, containing one of more subscriptions.
 
+        All included subscriptions need to use the same subscription ID.
+
         :param subscriptions: a sequence of subscriptions
-        :return: packet ID of the ``SUBSCRIBE`` request, or ``None`` if a request did
-            not need to be sent
+        :param max_qos: the maximum QoS to request. Leave as `None` to use the
+            subscription's value.
+        :return: packet ID of the ``SUBSCRIBE`` request.
 
+        When changing a subscription's QoS, pass the new max_qos value.
+        Update the subscription record after the operation was successful.
         """
-        self._out_require_state(MQTTClientState.CONNECTED)
-        new_subscriptions: list[Subscription] = []
-        for sub in subscriptions:
-            if sub.pattern in self._subscriptions:
-                self._subscription_counts[sub.pattern] += 1
-            else:
-                self._subscription_counts[sub.pattern] = 1
-                new_subscriptions.append(sub)
-                self._subscriptions[sub.pattern] = sub
+        subscr_id: int | None = None
 
-        if not new_subscriptions:
-            return None
+        # TODO remember the subscription for reconnect if not
+        self._out_require_state(MQTTClientState.CONNECTED)
+
+        for sub in subscriptions:
+            # If all subscriptions use a common ID, collect and use that.
+            # Otherwise don't.
+            if subscr_id is None:
+                subscr_id = sub.subscription_id
+            elif subscr_id != sub.subscription_id:
+                raise ValueError("Inconsistent subscription IDs")
 
         packet = MQTTSubscribePacket(
-            subscriptions=new_subscriptions, packet_id=self._generate_packet_id()
+            subscriptions=subscriptions,
+            packet_id=self._generate_packet_id(),
+            max_qos=max_qos,
         )
+        if subscr_id and self.may_subscription_id:
+            packet.properties[PropertyType.SUBSCRIPTION_IDENTIFIER] = subscr_id
         packet.encode(self._out_buffer)
         self._add_pending_packet(packet)
         return packet.packet_id
@@ -234,29 +239,19 @@ class MQTTClientStateMachine(BaseMQTTClientStateMachine):
         """
         Unsubscribe from one or more topic patterns.
 
-        If the internal subscription for any of the given patterns goes down to 0, an
-        ``UNSUBSCRIBE`` request is sent for those patterns.
+        Send an ``UNSUBSCRIBE`` request, containing one of more subscriptions.
 
         :param patterns: topic patterns to unsubscribe from
-        :return: packet ID of the ``UNSUBSCRIBE`` request, or ``None`` if a request did
-            not need to be sent
-
+        :return: packet ID of the ``UNSUBSCRIBE`` request
         """
-        self._out_require_state(MQTTClientState.CONNECTED)
-        patterns_to_remove: list[str] = []
-        for pattern in patterns:
-            if self._subscription_counts.get(pattern, 0) == 1:
-                del self._subscription_counts[pattern]
-                del self._subscriptions[pattern]
-                patterns_to_remove.append(pattern)
-            else:
-                self._subscription_counts[pattern] -= 1
-
-        if not patterns_to_remove:
+        try:
+            self._out_require_state(MQTTClientState.CONNECTED)
+        except MQTTProtocolError:
             return None
+            # TODO remember the unsubscription for reconnect
 
         packet = MQTTUnsubscribePacket(
-            patterns=patterns_to_remove, packet_id=self._generate_packet_id()
+            patterns=patterns, packet_id=self._generate_packet_id()
         )
         packet.encode(self._out_buffer)
         self._add_pending_packet(packet)

--- a/src/mqttproto/client_state_machine.py
+++ b/src/mqttproto/client_state_machine.py
@@ -52,7 +52,7 @@ class MQTTClientStateMachine(BaseMQTTClientStateMachine):
 
     @property
     def may_subscription_id(self) -> bool:
-        """Does the server support RETAINed messages?"""
+        """Does the server support subscription IDs?"""
         return self._may_subscription_id
 
     def reset(self, session_present: bool) -> None:

--- a/tests/test_state_machines.py
+++ b/tests/test_state_machines.py
@@ -78,16 +78,6 @@ def test_subscribe_unsubscribe(connected_client: MQTTClientStateMachine) -> None
     assert connected_client.unsubscribe(["foo/baz"]) == 3
 
 
-def test_duplicate_subscription(connected_client: MQTTClientStateMachine) -> None:
-    assert (
-        connected_client.subscribe([Subscription("foo/bar"), Subscription("foo/baz")])
-        == 1
-    )
-    assert connected_client.subscribe([Subscription("foo/bar")]) is None
-    assert connected_client.unsubscribe(["foo/bar"]) is None
-    assert connected_client.unsubscribe(["foo/bar"]) == 2
-
-
 def test_client_publish_qos0(
     client_session_pairs: list[
         tuple[MQTTClientStateMachine, MQTTBrokerClientStateMachine]

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -195,12 +195,6 @@ class TestSubscription:
         publish = MQTTPublishPacket(topic="foo/bar", payload="")
         assert not Subscription(pattern).matches(publish)
 
-    def test_higher_than_max_qos(self) -> None:
-        publish = MQTTPublishPacket(
-            topic="foo/bar", payload="", qos=QoS.AT_LEAST_ONCE, packet_id=1
-        )
-        assert not Subscription("foo/bar", max_qos=QoS.AT_MOST_ONCE).matches(publish)
-
     def test_single_level_wildcard_not_alone(self) -> None:
         with pytest.raises(
             InvalidPattern,

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -358,7 +358,7 @@ class TestMQTTPublishPacket:
             PropertyType.CONTENT_TYPE: "application/json",
             PropertyType.RESPONSE_TOPIC: "res/pon/se",
             PropertyType.CORRELATION_DATA: b"random",
-            PropertyType.SUBSCRIPTION_IDENTIFIER: 268_435_455,
+            PropertyType.SUBSCRIPTION_IDENTIFIER: [268_435_455],
             PropertyType.TOPIC_ALIAS: 65535,
         }
         user_properties = {"foo": "bar", "key2": "value2"}
@@ -607,7 +607,7 @@ class TestMQTTSubscribePacket:
             ),
         ]
         properties: dict[PropertyType, PropertyValue] = {
-            PropertyType.SUBSCRIPTION_IDENTIFIER: 268_435_455,
+            PropertyType.SUBSCRIPTION_IDENTIFIER: [268_435_455],
         }
         user_properties = {"foo": "bar", "key2": "value2"}
         packet = MQTTSubscribePacket(


### PR DESCRIPTION
This series of patches teaches mqttproto to use subscription identifiers instead of matching up topics. This speeds up incoming message processing considerably and prevents duplicates when you have overlapping topics and the server doesn't coalesce subscriptions (as indeed it's not required to).

It also speeds up the topic matcher, for when subscription IDs are not available.

Our broker now states (as required by MQTT) that it doesn't understand subscription IDs. That's for another PR …