### PR TITLE
Add missing request response information property to ConnectPacket

### DIFF
--- a/src/mqttproto/_types.py
+++ b/src/mqttproto/_types.py
@@ -587,6 +587,7 @@ class MQTTConnectPacket(MQTTPacket, PropertiesMixin):
             PropertyType.SESSION_EXPIRY_INTERVAL,
             PropertyType.AUTHENTICATION_METHOD,
             PropertyType.AUTHENTICATION_DATA,
+            PropertyType.REQUEST_RESPONSE_INFORMATION,
             PropertyType.REQUEST_PROBLEM_INFORMATION,
             PropertyType.RECEIVE_MAXIMUM,
             PropertyType.TOPIC_ALIAS_MAXIMUM,


### PR DESCRIPTION
Hi! The spec lists [`Request Response Information` as property of Connect packets](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901052). It's defined under `PropertyType` even, but not actually listed as allowed property in `MQTTConnectPacket`.